### PR TITLE
Fix wording in hazelcast-platform-operator-expose-externally.adoc

### DIFF
--- a/docs/modules/ROOT/pages/hazelcast-platform-operator-expose-externally.adoc
+++ b/docs/modules/ROOT/pages/hazelcast-platform-operator-expose-externally.adoc
@@ -27,7 +27,7 @@ Create a secret with your link:http://trialrequest.hazelcast.com/[Hazelcast Ente
 kubectl create secret generic hazelcast-license-key --from-literal=license-key=<hz-license-key>
 ----
 
-NOTE: Starting with version 5.13, Hazelcast Platform Operator only supports Hazelcast Enterprise cluster creation. Even the feature can be used in Hazelcast Open Source clusters, Hazelcast Platform Operator requires license key to run a cluster.
+NOTE: Starting with version 5.13, Hazelcast Platform Operator only supports cluster creation with Hazelcast Enterprise. Even though the feature can be used in Hazelcast Open Source clusters, Hazelcast Platform Operator requires a valid license key to create a cluster.
 
 WARNING: This tutorial uses LoadBalancer services to connect to Hazelcast from outside of the Kubernetes cluster. Therefore, it is essential to ensure that your Kubernetes cluster can assign public IPs to LoadBalancer services. This is particularly important if you are using a local Kubernetes cluster such as Minikube or Kind.
 


### PR DESCRIPTION
Just a small grammatical fix. Not familiar with the product enough to know if it is worth mentioning the open source version here, or that a cluster is somehow possible but with no link etc.